### PR TITLE
ci: align embedded NATS release flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    target-branch: main
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      maven-all:
+        patterns:
+          - '*'
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: main
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      actions-all:
+        patterns:
+          - '*'

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@81f3937399028513b70b4258e032ac856768dbfd
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@93dcc244b1713aeb9594aff65df1a2901ded707f
     with:
       semver_strategy: snapshot
       upstream_repository: nats-io/nats-server
@@ -43,7 +43,7 @@ jobs:
       contents: read
       deployments: write
       packages: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@81f3937399028513b70b4258e032ac856768dbfd
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@93dcc244b1713aeb9594aff65df1a2901ded707f
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -59,4 +59,4 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@81f3937399028513b70b4258e032ac856768dbfd
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@93dcc244b1713aeb9594aff65df1a2901ded707f

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -27,6 +27,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@81f3937399028513b70b4258e032ac856768dbfd
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@93dcc244b1713aeb9594aff65df1a2901ded707f
     with:
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -20,6 +20,6 @@ jobs:
       actions: write
       contents: write
       pull-requests: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_update_maven_wrapper.yml@81f3937399028513b70b4258e032ac856768dbfd
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_update_maven_wrapper.yml@93dcc244b1713aeb9594aff65df1a2901ded707f
     with:
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@81f3937399028513b70b4258e032ac856768dbfd
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@93dcc244b1713aeb9594aff65df1a2901ded707f
     with:
       force: ${{ inputs.force }}
       semver_strategy: snapshot
@@ -43,7 +43,7 @@ jobs:
       contents: read
       deployments: write
       packages: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@81f3937399028513b70b4258e032ac856768dbfd
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@93dcc244b1713aeb9594aff65df1a2901ded707f
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -59,7 +59,7 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@81f3937399028513b70b4258e032ac856768dbfd
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@93dcc244b1713aeb9594aff65df1a2901ded707f
 
   github:
     needs:
@@ -70,7 +70,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@81f3937399028513b70b4258e032ac856768dbfd
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@93dcc244b1713aeb9594aff65df1a2901ded707f
     with:
       commit_sha: ${{ needs.release.outputs.commit_sha }}
       version: ${{ needs.release.outputs.version }}

--- a/pom.xml
+++ b/pom.xml
@@ -133,8 +133,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>${java-version}</source>
-                    <target>${java-version}</target>
                     <release>${java-version}</release>
                 </configuration>
             </plugin>
@@ -145,6 +143,39 @@
                 <configuration>
                     <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <release>${java-version}</release>
+                            <nodeprecatedlist>true</nodeprecatedlist>
+                            <quiet>true</quiet>
+                            <doclint>none</doclint>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -235,41 +266,6 @@
             <id>central</id>
             <build>
                 <plugins>
-                    <!-- QUALITY GATE -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven-javadoc-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                                <configuration>
-                                    <release>${java-version}</release>
-                                    <nodeprecatedlist>true</nodeprecatedlist>
-                                    <quiet>true</quiet>
-                                    <!-- disable strict checking -->
-                                    <doclint>none</doclint>
-                                    <failOnError>false</failOnError>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>${maven-source-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
Pins the shared callers, attaches sources and Javadocs in every build, and enables weekly Dependabot updates. Held for Monday’s streaming release proof.