### PR TITLE
ci: manage NATS upstream property

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       maven-all:
         patterns:
           - '*'
+    ignore:
+      - dependency-name: berlin.yuna:nats-server
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,4 +1,5 @@
 # yuna-java-upstream: nats-io/nats-server
+# yuna-java-upstream-property: nats-server.version
 name: 🛠️ CI · Maintenance
 
 on:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,4 +1,4 @@
-# yuna-java-upstream: nats-io/nats-server
+# yuna-java-upstream: YunaBraska/nats-server
 # yuna-java-upstream-property: nats-server.version
 name: 🛠️ CI · Maintenance
 


### PR DESCRIPTION
Marks `nats-server.version` as the property managed by the central upstream-maintenance job and excludes that one dependency from Dependabot. The central job will update the property from the latest stable NATS release, regenerate Spring metadata with Maven verification, and send its maintenance branch through the normal PR build.